### PR TITLE
demo uart app readme fix

### DIFF
--- a/src/uart/Readme.md
+++ b/src/uart/Readme.md
@@ -1,12 +1,16 @@
 # to build
-
-cmake -DCMAKE_TOOLCHAIN_FILE=arm-none-eabi-toolchain.cmake -B build -S.
+```
+cmake -DCMAKE_TOOLCHAIN_FILE=config/arm-none-eabi-toolchain.cmake -B build -S.
 make -C build uart_app
+```
 
 
 # build with docker
+```
 docker build -t arm-docker-build config
 
 docker run --rm -v .:/src -w /src arm-docker-build bash -c "cmake -DCMAKE_TOOLCHAIN_FILE=config/arm-none-eabi-toolchain.cmake -B build -S."
 
 docker run --rm -v .:/src -w /src arm-docker-build bash -c "make -C build -j3 uart_app"
+```
+


### PR DESCRIPTION
- arm-none-eabi-toolchain.cmake is under config sub folder which need to tell cmake in CMAKE_TOOLCHAIN_FILE
- GitHub doesn't break lines when rendering (unless two spaces at each line end), added md to make it correctly break lines